### PR TITLE
Fixes condition for recursiveness while listing contents

### DIFF
--- a/src/FileStoreAdapter.php
+++ b/src/FileStoreAdapter.php
@@ -251,7 +251,7 @@ class FileStoreAdapter extends AbstractAdapter implements AdapterInterface
         foreach ($xml->file as $file) {
             $meta = $this->handleFileMetaData($directory, $file);
             $dir[$meta['path']] = $meta;
-            if (!$recursive || $meta['type'] == 'dir') {
+            if ($recursive && $meta['type'] == 'dir') {
                 $dir[$meta['path']]['children'] = $this->listContents($meta['path'], $recursive);
             }
         }


### PR DESCRIPTION
Attempts to find item's children only if `$recursive` parameter is TRUE and current item is of type `dir`
